### PR TITLE
Should warn the user when trying to subscribe twice to the same object or unsubscribe from not existing object

### DIFF
--- a/packages/bloc-core/src/bloczone/BlocZone.ts
+++ b/packages/bloc-core/src/bloczone/BlocZone.ts
@@ -44,14 +44,14 @@ export function createBlocZone<S extends object>(initialState: S): BlocZone<S> {
 	const setState = (newState: S) => Object.assign(state, newState)
 	const subscribe = (obj: object, listener: Subscription<S>): void => {
 		if (_listenerKeys.has(obj)) {
-			throw new Error('Object is already subscribed to this Bloc')
+			console.warn('Object is already subscribed to this Bloc')
 		}
 		_listeners.set(obj, listener)
 		_listenerKeys.set(obj, null)
 	}
 	const unsubscribe = (obj: object): void => {
 		if (!_listenerKeys.has(obj)) {
-			throw new Error('Object is not subscribed to this Bloc')
+			console.warn('Object is not subscribed to this Bloc')
 		}
 		_listeners.delete(obj)
 		_listenerKeys.delete(obj)

--- a/packages/bloc-core/src/bloczone/__tests__/BlocZone.spec.ts
+++ b/packages/bloc-core/src/bloczone/__tests__/BlocZone.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals'
+import { describe, test, expect, jest } from '@jest/globals'
 import { createBlocZone } from '../BlocZone'
 import type { Subscription } from '../../types'
 
@@ -57,14 +57,16 @@ describe('createBlocZone', () => {
     }).not.toThrowError()
   })
 
-  test('should throw an error when trying to unsubscribe an object that is not subscribed', () => {
+  test('should warn when trying to unsubscribe an object that is not subscribed ', () => {
     const initialState: AppState = { count: 0 }
     const bloc = createBlocZone(initialState)
 
     const unknownObject = {}
 
-    expect(() => {
-      bloc.unsubscribe(unknownObject)
-    }).toThrowError('Object is not subscribed to this Bloc')
+		jest.spyOn(console, 'warn')
+
+		bloc.unsubscribe(unknownObject)
+
+		expect(console.warn).toHaveBeenCalledWith('Object is not subscribed to this Bloc')
   })
 })


### PR DESCRIPTION
Should warn the user when trying to subscribe twice to the same object or unsubscribe from not existing object.

---
name: [double-subscription-with-the-same-object](https://github.com/OliverArthurNardi/blocZone/issues/6)
about: Now, when a user tries to subscribe to an object twice, they will receive a warning.
title: Warn user from double subscribe object or unsubscribe object
labels: bug
assignees: @OliverArthur

---

## Description

Instead of throwing an error I think issuing a warning can be a good alternative in this situation. This way, you inform the user that the object is already subscribed, without stopping the execution of the program, and the same for unsubscribing object which is not subscribed.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Updated unit-test 

## Changes Made

- subscribe:  now warn the user when trying to subscribe twice.
- unsubscribe: now warn the user when trying to subscribe to not subscribe object. 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>